### PR TITLE
Prevent mixed content error by including fonts directly

### DIFF
--- a/apps/video/SouthRidgeVideo/index.html
+++ b/apps/video/SouthRidgeVideo/index.html
@@ -3,8 +3,25 @@
   <head>
     <meta charset="UTF-8" />
     <title>South Ridge Video</title>
-   <link href="manifest.json" rel="manifest">
-<link href="//db.onlinewebfonts.com/c/88bdc70ec292cc29451932f9875b378a?family=SegoeUIMonoW01-Regular" rel="stylesheet" type="text/css"/>        <link href="reset.css" rel="stylesheet" type="text/css"  />
+    <link href="manifest.json" rel="manifest">
+    <style>
+      /*
+        www.OnlineWebFonts.Com 
+        You must credit the author Copy this link on your web 
+        <div>Font made from <a href="http://www.onlinewebfonts.com">oNline Web Fonts</a>is licensed by CC BY 3.0</div>
+        OR
+        <a href="http://www.onlinewebfonts.com">oNline Web Fonts</a>
+      */
+      @font-face {font-family: "SegoeUIMonoW01-Regular";
+        src: url("https://db.onlinewebfonts.com/t/88bdc70ec292cc29451932f9875b378a.eot"); /* IE9*/
+        src: url("https://db.onlinewebfonts.com/t/88bdc70ec292cc29451932f9875b378a.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+        url("https://db.onlinewebfonts.com/t/88bdc70ec292cc29451932f9875b378a.woff2") format("woff2"), /* chrome firefox */
+        url("https://db.onlinewebfonts.com/t/88bdc70ec292cc29451932f9875b378a.woff") format("woff"), /* chrome firefox */
+        url("https://db.onlinewebfonts.com/t/88bdc70ec292cc29451932f9875b378a.ttf") format("truetype"), /* chrome firefox opera Safari, Android, iOS 4.2+*/
+        url("https://db.onlinewebfonts.com/t/88bdc70ec292cc29451932f9875b378a.svg#SegoeUIMonoW01-Regular") format("svg"); /* iOS 4.1- */
+      }	    
+    </style>
+    <link href="reset.css" rel="stylesheet" type="text/css"  />
     <link href="app.css" rel="stylesheet" type="text/css"  />
     <link rel="stylesheet" type="text/css" href="style.css">
     <script>


### PR DESCRIPTION
Even if one references https://db.onlinewebfonts.com/c/88bdc70ec292cc29451932f9875b378a?family=SegoeUIMonoW01-Regular explicitly over https, the resulting font URLs still use http. Sad. This pull request fixes this issue.
CC: @boyofgreen 